### PR TITLE
check if frame matches sourcemap.file

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,12 +51,13 @@ proto._prepare = function () {
 proto._mapStack = function (stack) {
   var self = this;
 
-  var generatedFile = stack[0].filename;
+  var generatedFile = self._sourcemap.file;
+  var re = new RegExp(generatedFile + '$');
 
   for (var i = 0; i < stack.length; i++) {
     var frame = stack[i];
 
-    if (frame.filename !== generatedFile) {
+    if (!re.test(frame.filename)) {
       continue;
     }
 

--- a/test/onefile.js
+++ b/test/onefile.js
@@ -12,16 +12,17 @@ test('\none file returning error', function (t) {
   var res = bundleNmap('onefile', function (err, res) {
     if (err) return console.error(err);
 
+    res.map.file = 'full/path/to/bundle.js';
+
     var sm = stackMapper(res.map);
     var error = res.main();
     var frames = v8ToSm(error);
 
-    var actual = sm.map(frames).slice(0, 3);
+    var actual = sm.map(frames).slice(0, 2);
 
     var expected = fromStr([
         __dirname + '/onefile/main.js:6:12',
         __dirname + '/onefile/main.js:8:10',
-        __dirname + '/onefile.js:16:21'
     ]);
 
     t.deepEqual(actual, expected);

--- a/test/prepared/onefile.js
+++ b/test/prepared/onefile.js
@@ -20,7 +20,7 @@ var origStack = [
 
 var map = {
   version: 3,
-  file: 'generated.js',
+  file: '/path/to/bundle.js',
   sources: [ '/Users/thlorenz/dev/js/projects/stack-mapper/test/onefile/main.js' ],
   names: [],
   mappings: ';AAAA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA',

--- a/test/prepared/threefiles-throw.js
+++ b/test/prepared/threefiles-throw.js
@@ -19,7 +19,7 @@ var origStack = [
 ]
 
 var map = { version: 3,
-  file: 'generated.js',
+  file: '/path/to/bundle.js',
   sources:
    [ '/Users/thlorenz/dev/js/projects/stack-mapper/test/threefiles-throw/barbar.js',
      '/Users/thlorenz/dev/js/projects/stack-mapper/test/threefiles-throw/foobar.js',
@@ -31,7 +31,7 @@ var map = { version: 3,
      '\'use strict\';\n\nvar go = module.exports = function foobar() {\n  throw new Error(\'shouldn\\\'t have called foobar ;)\');  \n};\n',
      '\'use strict\';\n\nvar barbar = require(\'./barbar\');\n\nmodule.exports = function main() {\n  var a = 1;\n  function bar() {\n    return barbar();\n  }\n  return bar();\n}\n' ] }
 
-test('\nthree files returning, one throwing an error no source', function (t) {
+test('three files returning, one throwing an error no source', function (t) {
   var sm = stackMapper(map);
   var actual = sm.map(fromStr(origStack));
 

--- a/test/prepared/twofiles.js
+++ b/test/prepared/twofiles.js
@@ -19,7 +19,7 @@ var origStack = [
 ]
 
 var map = { version: 3,
-  file: 'generated.js',
+  file: '/path/to/bundle.js',
   sources:
    [ '/Users/thlorenz/dev/js/projects/stack-mapper/test/twofiles/barbar.js',
      '/Users/thlorenz/dev/js/projects/stack-mapper/test/twofiles/main.js' ],
@@ -29,7 +29,7 @@ var map = { version: 3,
    [ '\'use strict\';\n\nfunction foobar() {\n  return new Error();\n}\n\nvar go = module.exports = function () {\n  return foobar();  \n};\n',
      '\'use strict\';\n\nvar barbar = require(\'./barbar\');\n\nmodule.exports = function main() {\n  var a = 1;\n  function bar() {\n    return barbar();\n  }\n  return bar();\n}\n' ] }
 
-test('\ntwo files returning error no sources', function (t) {
+test('two files returning error no sources', function (t) {
   var sm = stackMapper(map);
   var actual = sm.map(fromStr(origStack));
 

--- a/test/threefiles-assert.js
+++ b/test/threefiles-assert.js
@@ -10,24 +10,25 @@ var test = require('tape')
 test('\nthree files returning, one with assert exception', function (t) {
   var res = bundleNmap('threefiles-assert', function (err, res) {
     if (err) return console.error(err);
-     
+
+    res.map.file = 'full/path/to/bundle.js';
+
     var sm = stackMapper(res.map);
     var error;
-    try { 
-      res.main(); 
-    } catch (e) { 
-      error = e; 
+    try {
+      res.main();
+    } catch (e) {
+      error = e;
     }
 
     var frames = v8ToSm(error);
-    var actual = sm.map(frames).slice(0, 5);
+    var actual = sm.map(frames).slice(0, 4);
 
     var expected = fromStr([
       __dirname + '/threefiles-assert/foobar.js:6:3',
       __dirname + '/threefiles-assert/barbar.js:6:10',
       __dirname + '/threefiles-assert/main.js:8:12',
       __dirname + '/threefiles-assert/main.js:10:10',
-      __dirname + '/threefiles-assert.js:17:11'
     ]);
 
     t.deepEqual(actual, expected);

--- a/test/threefiles-throw.js
+++ b/test/threefiles-throw.js
@@ -14,24 +14,25 @@ function inspect(obj, depth) {
 test('three files returning, one throwing an error', function (t) {
   var res = bundleNmap('threefiles-throw', function (err, res) {
     if (err) return console.error(err);
-     
+
+    res.map.file = 'full/path/to/bundle.js';
+
     var sm = stackMapper(res.map);
     var error;
-    try { 
-      res.main(); 
-    } catch (e) { 
-      error = e; 
+    try {
+      res.main();
+    } catch (e) {
+      error = e;
     }
 
     var frames = v8ToSm(error);
-    var actual = sm.map(frames).slice(0, 5);
+    var actual = sm.map(frames).slice(0, 4);
 
     var expected = fromStr([
       __dirname + '/threefiles-throw/foobar.js:4:9',
       __dirname + '/threefiles-throw/barbar.js:6:10',
       __dirname + '/threefiles-throw/main.js:8:12',
       __dirname + '/threefiles-throw/main.js:10:10',
-      __dirname + '/threefiles-throw.js:21:11'
     ]);
 
     t.deepEqual(actual, expected);

--- a/test/twofiles.js
+++ b/test/twofiles.js
@@ -14,18 +14,19 @@ function inspect(obj, depth) {
 test('two files returning error no source', function (t) {
   var res = bundleNmap('twofiles', function (err, res) {
     if (err) return console.error(err);
-     
+
+    res.map.file = 'full/path/to/bundle.js';
+
     var sm = stackMapper(res.map);
     var error = res.main();
     var frames = v8ToSm(error);
-    var actual = sm.map(frames).slice(0, 5);
+    var actual = sm.map(frames).slice(0, 4);
 
     var expected = fromStr([
           __dirname + '/twofiles/barbar.js:4:10',
           __dirname + '/twofiles/barbar.js:8:10',
           __dirname + '/twofiles/main.js:8:12',
           __dirname + '/twofiles/main.js:10:10',
-          __dirname + '/twofiles.js:19:21'
     ]);
 
     t.deepEqual(actual, expected);


### PR DESCRIPTION
Using the first filename of the frame will lead to improper behavior
when the frames don't start with the filename of the file we are
actually mapping against.

This works in IE 6+ now (tested).
